### PR TITLE
fix glue between [401]/[402]/[202] and [3] in banjiao/kaiming of Simplified Chinese

### DIFF
--- a/jfm-bjsh.lua
+++ b/jfm-bjsh.lua
@@ -192,7 +192,7 @@ luatexja.jfont.define_jfm {
         depth = 0.12,
         italic = 0,
         glue = {
-            [3] = {0.25, 0, 0.25, priority = -1}
+            [3] = {0, 0.25, 0, priority = -1}
         }
     },
     [5] = {

--- a/jfm-bjsv.lua
+++ b/jfm-bjsv.lua
@@ -112,7 +112,7 @@ luatexja.jfont.define_jfm {
         depth = 0.5,
         italic = 0,
         glue = {
-            [3] = {0.25, 0.0, 0.25, priority = -1}
+            [3] = {0, 0.25, 0, priority = -1}
         }
     },
     [3] = {
@@ -167,7 +167,7 @@ luatexja.jfont.define_jfm {
         depth = 0.5,
         italic = 0,
         glue = {
-            [3] = {0.25, 0.0, 0.25, priority = -1}
+            [3] = {0, 0.25, 0, priority = -1}
         }
     },
     [5] = {

--- a/jfm-kmsh.lua
+++ b/jfm-kmsh.lua
@@ -192,7 +192,7 @@ luatexja.jfont.define_jfm {
         depth = 0.12,
         italic = 0,
         glue = {
-            [3] = {0.25, 0, 0.25, priority = -1}
+            [3] = {0, 0.25, 0, priority = -1}
         }
     },
     [5] = {

--- a/jfm-kmsv.lua
+++ b/jfm-kmsv.lua
@@ -112,7 +112,7 @@ luatexja.jfont.define_jfm {
         depth = 0.5,
         italic = 0,
         glue = {
-            [3] = {0.25, 0.0, 0.25, priority = -1}
+            [3] = {0, 0.25, 0, priority = -1}
         }
     },
     [3] = {
@@ -167,7 +167,7 @@ luatexja.jfont.define_jfm {
         depth = 0.5,
         italic = 0,
         glue = {
-            [3] = {0.25, 0.0, 0.25, priority = -1}
+            [3] = {0, 0.25, 0, priority = -1}
         }
     },
     [5] = {


### PR DESCRIPTION
半角・開明式の簡体中国語の全角疑問・感嘆符 [401]/[402] と縦組みのコロン・セミコロン [202] と中点 [3] のグルーは `{0, 0.25, 0}` のはずですが、私はまちがえて `{0.25, 0, 0.25}` に設定してしまいました。ここで修正します。

The glue between {full width question mark / exclamation mark and colon / semicolon in vertical writing mode} and middle dot should be `{0, 0.25, 0}`, but I made a mistake to set it to `{0.25, 0, 0.25}`. Fix it in this PR.