### PR TITLE
update round_threshold setting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 ListLee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jfm-ja_JP.lua
+++ b/jfm-ja_JP.lua
@@ -47,7 +47,8 @@ luatexja.jfont.define_jfm {
             [1] = aki(0.5, -1),
             [22] = aki(0.25),
             [3] = aki(0.25, -1)
-        }
+        },
+        round_threshold = 0.01
     },
     [1] = {
         -- 开括号

--- a/jfm-zh_CN.lua
+++ b/jfm-zh_CN.lua
@@ -52,7 +52,8 @@ luatexja.jfont.define_jfm {
         glue = {
             [1] = aki(0.5, -1),
             [3] = aki(0.25, -1)
-        }
+        },
+        round_threshold = 0.01
     },
     [1] = {
         -- 开括号

--- a/jfm-zh_TW.lua
+++ b/jfm-zh_TW.lua
@@ -48,7 +48,8 @@ luatexja.jfont.define_jfm {
             [22] = is_vt and {} or aki(0.25),
             [3] = aki(0.25, -1),
             [4] = aki(0.25, 1, true)
-        }
+        },
+        round_threshold = 0.01
     },
     [1] = {
         -- 开括号


### PR DESCRIPTION
「源ノ」フォントにとってはとても大事な設定ですが、今まで気づきませんでした…

>このフィールドに正の数 r が指定されていたとし，文字クラス 0 で指定されている文字幅が w，文字クラス 0 に属する文字のグリフの幅が w' であったとする． n = nint(w/w') としたとき，もし w' > w かつ |w/w' - n| < r であれば，JFM で文字幅 nw が指定されたものとして扱う．

この部分の説明はちょっとわかりませんが…ここの「文字クラス 0 で指定されている文字幅の w」と「文字クラス 0 に属する文字のグリフの幅の w'」は逆ではありませんか。w' は指定されている文字幅、w はグリフの幅で、w' > w は w > w'、最後の nw も nw' だと思います。

例として、r = 0.01、w = 1、w' = 2 のとき、n = nint(w/w') = nint(1/2) = 1。w' > w、|w/w' - n| = 1/2 > r、何も起こりません。逆に w = 2、w' = 1 のとき、n = nint(w/w') = nint(2) = 2。w > w'、|w/w' - n| = 0 < r = 0.01、JFM で指定する文字幅は nw' = 2 になります。

日本語が下手なので、もし認識的な間違いがあったらご指摘ください。